### PR TITLE
Fixed inverted gateBox door position

### DIFF
--- a/blebox/gateBox.js
+++ b/blebox/gateBox.js
@@ -93,7 +93,7 @@ GateBoxAccessoryWrapper.prototype.getCurrentDoorStateValue = function () {
     var state = this.currentDoorStateCharacteristic.OPEN; //default value
     if (this.gateInfo) {
         var currentPosition = Number(this.gateInfo.currentPos) || 0;
-        if (currentPosition == 100) {
+        if (currentPosition == 0) {
             state = this.currentDoorStateCharacteristic.CLOSED;
         }
     }

--- a/blebox/switchBoxD.js
+++ b/blebox/switchBoxD.js
@@ -107,7 +107,7 @@ SwitchBoxDAccessoryWrapper.prototype.getServiceName = function (relayNumber) {
 
 SwitchBoxDAccessoryWrapper.prototype.getCurrentRelayValue = function (relayNumber) {
     var result = false;
-    if (this.relay && this.relays.length > relayNumber) {
+    if (this.relays && this.relays.length > relayNumber) {
         result = this.relays[relayNumber].state ? true : false
     }
     return result;


### PR DESCRIPTION
According to Blebox API docs for gateBox, currentPos for gatebox means "Closed", not "Open", so I have updated the gateBox.js file to reflect that and make sure HomeKit shows the position of the door correctly.