### PR TITLE
Add option to provide ip list for scan

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,8 @@ Configuration sample (remove comments) :
             {
             "platform": "BleBoxPlatform", // Don't change this
             "name": "SomePlatformName" // Custom platform name
-            "NEXT_SCAN_DELAY_IN_MIN" : 0 // (Optional, default: 0) How often platfrom should scan network for blebox devices( 0 - only once at startup, Other value - number of minutes beetween scaning) 
+            "NEXT_SCAN_DELAY_IN_MIN" : 0 // (Optional, default: 0) How often platform should scan network for blebox devices( 0 - only once at startup, Other value - number of minutes between scanning)
+            "IP_LIST" : null // (Optional, default: null) Provide a IP list to scan for blebox devices, example value: ["192.168.0.191","192.168.0.192","192.168.10.19"]) 
         }
 
     ],

--- a/platform/bleboxPlatform.js
+++ b/platform/bleboxPlatform.js
@@ -15,7 +15,12 @@ class BleBoxPlatform {
         this.homebridge = homebridge;
         this.api = api;
 
-        this.prepareIpListToScan();
+        if (this.config["IP_LIST"]) {
+            this.log("IP_LIST is defined, will use it instead of local subnet");
+            this.ipList = this.config["IP_LIST"]
+        } else {
+            this.prepareIpListToScan();
+        }
 
         this.api.on('didFinishLaunching', function () {
             this.startSearching();


### PR DESCRIPTION
Hi,
I decided to move my IOT device to different subnet and realize it's not supported by homebridge-blebox

So I created this small fix to have an option to provide IP List for scan instead of scanning homebridge subnet.

Also small typo fix in readme file.